### PR TITLE
Ensure java is installed before installing elastic search.

### DIFF
--- a/mac
+++ b/mac
@@ -184,6 +184,7 @@ brew_install_or_upgrade "redis"
 fancy_echo "If redis was installed, you will need to run 'brew services start redis' to start it."
 
 # Elasticsearch
+brew_cask_install "java"
 brew_install_or_upgrade "elasticsearch"
 fancy_echo "If elasticsearch was installed, you will need to run 'brew services start elasticsearch' to start it."
 

--- a/mac
+++ b/mac
@@ -77,6 +77,10 @@ brew_is_installed() {
   brew list -1 | grep -Fqx "$1"
 }
 
+brew_cask_is_installed() {
+  brew cask list -1 | grep -Fqx "$1"
+}
+
 brew_is_upgradable() {
   ! brew outdated --quiet "$1" >/dev/null
 }


### PR DESCRIPTION
Java is a dependency for elastic search, so I added a line to make sure it is installed before installing elastic search.
